### PR TITLE
update praesidium 2020

### DIFF
--- a/index.html
+++ b/index.html
@@ -598,7 +598,7 @@
             <a href="https://www.facebook.com/homeastridgent/"><i class="fa fa-facebook fa-2x"></i></a>
         </div>
         <h6>&copy; 2018 Home Astrid By Tibo vanheule</h6>
-        <h6><a href="vorig.html">Klik hier voor alle vorige ICT's</a></h6>
+        <!-- <h6><a href="vorig.html">Klik hier voor alle vorige ICT's</a></h6> -->
         <h6><a href="privacy%20policy.html">Privacy policy</a></h6>
     </div>
 </footer>

--- a/vorig.html
+++ b/vorig.html
@@ -122,33 +122,33 @@
             <li><strong>2017-2018</strong> DEPREZ Mathijs</li>
             <li><strong>2018-2019</strong> TROCH Arend</li>
             <li><strong>2019-2020</strong> DANGREAU Lisa</li>
+            <li><strong>2020-2021</strong> MARGO Thibeau</li>
         </ul>
     </div>
 </section>
 <section class="light-bg">
     <div class="container">
-        <h2>Praesidium 2019</h2>
+        <h2>Praesidium 2020</h2>
         <ul class="leftText">
-            <li><strong>PRAESES</strong> Lisa Dangreau</li>
-            <li><strong>VICE</strong> Elien Verbrugge</li>
-            <li><strong>PENNING</strong> Thibeau Margo</li>
-            <li><strong>SECRETARIS</strong> Michelle Borra</li>
-            <li><strong>FEEST</strong> Minne de Clercq</li>
-            <li><strong>FEEST</strong> Michiel Demeyere</li>
-            <li><strong>BAR</strong> Juan c. gil Ramos</li>
-            <li><strong>BAR</strong> Jennifer Bosseloirs</li>
-            <li><strong>SPORT</strong> Joeri Verschoren</li>
+            <li><strong>PRAESES</strong> Thibeau Margo</li>
+            <li><strong>VICE</strong> Joeri Verschoren</li>
+            <li><strong>PENNING</strong> Robin De Wulf</li>
+            <li><strong>SECRETARIS</strong> Fleur Ghyselen</li>
+            <li><strong>FEEST</strong> Merel Verminck</li>
+            <li><strong>FEEST</strong> Kato Lauwers</li>
+            <li><strong>BAR</strong> Axin Van de Maele</li>
+            <li><strong>BAR</strong> Arthur Claeys</li>
             <li><strong>SPORT</strong> Robbe Adriaens</li>
-            <li><strong>PR</strong> Ranald Vandersteene</li>
-            <li><strong>SCRIPTOR</strong> Eliza Bogaert</li>
-            <li><strong>SCHACHTENTEMMER</strong> Akalemwa de Waegeneire</li>
-            <li><strong>CULTUUR</strong> Tibo Vanheule</li>
-            <li><strong>CULTUUR</strong> Lemmy de Wolf</li>
-            <li><strong>ICT</strong> Tibo Vanheule</li>
+            <li><strong>SPORT</strong> Kylian Decroix</li>
+            <li><strong>SCRIPTOR</strong> Laura Dewaele</li>
+            <li><strong>SCHACHTENTEMMER</strong> Pauline Dournez</li>
+            <li><strong>KEIZER CULTUUR</strong> Lemmy De Wolf</li>
+            <li><strong>CULTUUR</strong> Julie Van Esbroeck</li>
+            <li><strong>ICT</strong> Robbe Adriaens</li>
             <li><strong>MILIEU</strong> Heike Krenn</li>
-            <li><strong>MILIEU</strong> Emily Ruilova</li>
-            <li><strong>METER</strong> Kaat van der Haegen</li>
-            <li><strong>PETER</strong> Bart van Balkom</li>
+            <li><strong>ZEDEN</strong> Joran Maes</li>
+            <li><strong>METER</strong> Lisa Dangreau</li>
+            <li><strong>METER</strong> Elien Verbrugge</li>
         </ul>
     </div>
 </section>


### PR DESCRIPTION
Replaced the names of praesidium 2019 to the new praesidium of 2020 + removed link to "all past ICTs"